### PR TITLE
Коммит: Структурирование импортов в SCSS и изменение метода импорта в Vite конфиге

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,7 +1,7 @@
-@import './variables/colors';
-@import './mixins/typo';
-@import './mixins/controls';
-@import './mixins/media';
-@import './mixins/helpers';
-@import './mixins/loading';
-@import './mixins/scrollbar';
+@forward './mixins/media';
+@forward './mixins/typo';
+@forward './mixins/controls';
+@forward './mixins/helpers';
+@forward './mixins/loading';
+@forward './mixins/scrollbar';
+@forward './variables/colors';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   css: {
     preprocessorOptions: {
-      scss: { additionalData: `@import "@/styles/main";`, api: 'modern-compiler' },
+      scss: { additionalData: `@use "@/styles/main" as *;`, api: 'modern-compiler' },
     },
   },
 })


### PR DESCRIPTION
Структурирование импортов в SCSS и изменение метода импорта в Vite конфиге

- Переорганизовал порядок импортов в файле `src/styles/main.scss` согласно стилю SCSS 1.3, используя ключевое слово `@forward`.
- Изменил способ импорта файла стилей в `vite.config.ts`, заменив `@import` на `@use` для более современного и модульного подхода к использованию SCSS.